### PR TITLE
fix(api):modify the query method of account authorization status.

### DIFF
--- a/src/api/monitor.py
+++ b/src/api/monitor.py
@@ -376,12 +376,14 @@ class DatabaseConnectionCheck(BaseAPI):
                 message = "When approveType != null, approveScope/hostIp/hostPort/userName/password is required"
                 return self.construct_error_response_entity(code=400, message=message)
             else:
-                message, grant_action, success = monitor_database_connection_check(
+                message, grant_action, success = check_monitor_database(
                     host_ip=args['hostIp'],
                     host_port=args['hostPort'],
                     user_name=args['userName'],
                     password=args['password'],
-                    database_name=args['databaseName']
+                    database_name=args['databaseName'],
+                    database_alias=args['databaseAlias'],
+                    user_id = self.user_id
                 )
 
                 if success:

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -28,12 +28,13 @@ class Utils(object):
 
     @staticmethod
     def remove_sql_text_affects_parser(sql):
-        sql = sql.lower()
+        sql = sql.lower().strip()
         sql = Utils.remove_hint_and_annotate(sql)
         sql = Utils.replace_interval_day(sql)
         sql = Utils.remove_force_index(sql)
         sql = Utils.remove_cast(sql)
         sql = Utils.remove_now_in_insert(sql)
+        sql = Utils.remove_semicolon(sql)
         return sql
 
     @staticmethod
@@ -72,6 +73,11 @@ class Utils(object):
     @staticmethod
     def get_db_id(database_alias, user_id):
         return database_alias + '-' + user_id
+
+    @staticmethod
+    def remove_semicolon(sql):
+        sql = sql.strip()
+        return sql[:-1] if sql[-1] == ';' else sql
 
 
 def fun_diff_secs(date1, date2):

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -71,13 +71,13 @@ class Utils(object):
         return sql
 
     @staticmethod
-    def get_db_id(database_alias, user_id):
-        return database_alias + '-' + user_id
-
-    @staticmethod
     def remove_semicolon(sql):
         sql = sql.strip()
         return sql[:-1] if sql[-1] == ';' else sql
+
+    @staticmethod
+    def get_db_id(database_alias, user_id):
+        return database_alias + '-' + user_id
 
 
 def fun_diff_secs(date1, date2):

--- a/test/common/test_utils.py
+++ b/test/common/test_utils.py
@@ -74,7 +74,7 @@ class MyTestCase(unittest.TestCase):
         /* trace_id=0b7c9b6f16766093900011105128699,rpc_id=0.9ef939e.8.5 */                      
         SELECT /*+ index(midas_record_value idx_tenant_time) */                 DISTINCT(trace_id)             FROM                 midas_record_value where tenant='insttrade' and is_expired=1  order by gmt_modified asc limit 500        """
         sql = Utils.remove_sql_text_affects_parser(sql)
-        assert sql == """select                  distinct(trace_id)             from                 midas_record_value where tenant=\'insttrade\' and is_expired=1  order by gmt_modified asc limit 500        """
+        assert sql == """select                  distinct(trace_id)             from                 midas_record_value where tenant=\'insttrade\' and is_expired=1  order by gmt_modified asc limit 500"""
 
     def test_semicolon(self):
         sql = """SELECT * FROM a;"""

--- a/test/common/test_utils.py
+++ b/test/common/test_utils.py
@@ -16,6 +16,7 @@ import unittest
 
 from src.common.utils import Utils
 
+
 class MyTestCase(unittest.TestCase):
 
     def test_remove_hint_and_annotate(self):
@@ -74,6 +75,15 @@ class MyTestCase(unittest.TestCase):
         SELECT /*+ index(midas_record_value idx_tenant_time) */                 DISTINCT(trace_id)             FROM                 midas_record_value where tenant='insttrade' and is_expired=1  order by gmt_modified asc limit 500        """
         sql = Utils.remove_sql_text_affects_parser(sql)
         assert sql == """select                  distinct(trace_id)             from                 midas_record_value where tenant=\'insttrade\' and is_expired=1  order by gmt_modified asc limit 500        """
+
+    def test_semicolon(self):
+        sql = """SELECT * FROM a;"""
+        sql = Utils.remove_sql_text_affects_parser(sql)
+        assert sql == """select * from a"""
+
+        sql = """SELECT * FROM a"""
+        sql = Utils.remove_sql_text_affects_parser(sql)
+        assert sql == """select * from a"""
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix(api):modify the query method of account authorization status. fix #67 

Originally, the authority was queried by show grants for user_name.But this way is not flexible enough
Change to use the internal table to query.
Adapted to MySQL and OceanBase.
