### PR TITLE
chore: remove the log error of primary key conflict

### DIFF
--- a/src/common/db_query.py
+++ b/src/common/db_query.py
@@ -553,7 +553,10 @@ class DealMetaDBInfo():
         try:
             self.meta_conn.func_write_storedb(sql_list, store_sql)
         except Exception as e:
-            log.exception(e)
+            # In the process of repeated collection, data duplication is very common.
+            # In order to keep the log information clean, the log error of primary key conflict is not printed
+            if 'Duplicate entry' not in str(e):
+                log.exception(e)
 
     def disconn_storedb(self):
         try:

--- a/src/schedule_task/run_sqless_schedule.py
+++ b/src/schedule_task/run_sqless_schedule.py
@@ -78,4 +78,4 @@ def schedule_func():
 if __name__ == '__main__':
     while True:
         schedule_func()
-        time.sleep(60)
+        time.sleep(5)


### PR DESCRIPTION
In the process of repeated collection, data duplication is very common.
In order to keep the log information clean, the log error of primary key conflict is not printed. close #71 