### PR TITLE
fix(parser):support parameterization in limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ parser_table.py
 expression_parser.out
 expression_parser_table.py
 save/*
-*/SQL_Lifecycle_Management.egg-info/*
+SQL_Lifecycle_Management.egg-info/*

--- a/src/parser/mysql_parser/parser.py
+++ b/src/parser/mysql_parser/parser.py
@@ -484,12 +484,10 @@ def p_null_ordering_opt(p):
 
 # LIMIT
 def p_limit_opt(p):
-    r"""limit_opt : LIMIT number
-    | LIMIT number COMMA number
-    | LIMIT QM
-    | LIMIT QM COMMA QM
+    r"""limit_opt : LIMIT parameterization
+    | LIMIT parameterization COMMA parameterization
+    | LIMIT parameterization OFFSET parameterization
     | LIMIT ALL
-    | LIMIT number OFFSET number
     | empty"""
     if len(p) < 5:
         p[0] = (0, p[2]) if p[1] else None
@@ -498,6 +496,13 @@ def p_limit_opt(p):
             p[0] = (p[2], p[4])
         else:
             p[0] = (p[4], p[2])
+
+
+def p_parameterization(p):
+    r"""parameterization : number
+    | QM
+    """
+    p[0] = p[1]
 
 
 def p_number(p):

--- a/src/parser/oceanbase_parser/parser.py
+++ b/src/parser/oceanbase_parser/parser.py
@@ -1093,7 +1093,7 @@ def p_function_call(p):
     | CURRENT_DATE LPAREN RPAREN"""
     if len(p) == 5:
         distinct = p[3] is None or (
-                isinstance(p[3], str) and p[3].upper() == "DISTINCT"
+            isinstance(p[3], str) and p[3].upper() == "DISTINCT"
         )
         p[0] = FunctionCall(
             p.lineno(1), p.lexpos(1), name=p[1], distinct=distinct, arguments=p[3]

--- a/src/parser/oceanbase_parser/parser.py
+++ b/src/parser/oceanbase_parser/parser.py
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 from __future__ import print_function
 
 import types
+
+from ply import yacc
+from src.optimizer.optimizer_enum import IndexType
+from src.parser.oceanbase_parser.lexer import tokens
 from src.parser.tree.expression import (
     ArithmeticBinaryExpression,
     ArithmeticUnaryExpression,
@@ -36,6 +40,7 @@ from src.parser.tree.expression import (
     SubqueryExpression,
     WhenClause,
 )
+from src.parser.tree.field_type import UNSPECIFIEDLENGTH, FieldType, MySQLType
 from src.parser.tree.grouping import SimpleGroupBy
 from src.parser.tree.join_criteria import JoinOn, JoinUsing, NaturalJoin
 from src.parser.tree.literal import (
@@ -56,11 +61,6 @@ from src.parser.tree.sort_item import SortItem
 from src.parser.tree.statement import Delete, Insert, Query, Update
 from src.parser.tree.table import Table, TableSubquery
 from src.parser.tree.values import Values
-from src.parser.tree.field_type import UNSPECIFIEDLENGTH, FieldType, MySQLType
-
-from ply import yacc
-from src.optimizer.optimizer_enum import IndexType
-from src.parser.oceanbase_parser.lexer import tokens
 
 tokens = tokens
 
@@ -483,12 +483,10 @@ def p_null_ordering_opt(p):
 
 # LIMIT
 def p_limit_opt(p):
-    r"""limit_opt : LIMIT number
-    | LIMIT number COMMA number
-    | LIMIT QM
-    | LIMIT QM COMMA QM
+    r"""limit_opt : LIMIT parameterization
+    | LIMIT parameterization COMMA parameterization
+    | LIMIT parameterization OFFSET parameterization
     | LIMIT ALL
-    | LIMIT number OFFSET number
     | empty"""
     if len(p) < 5:
         p[0] = (0, p[2]) if p[1] else None
@@ -497,6 +495,13 @@ def p_limit_opt(p):
             p[0] = (p[2], p[4])
         else:
             p[0] = (p[4], p[2])
+
+
+def p_parameterization(p):
+    r"""parameterization : number
+    | QM
+    """
+    p[0] = p[1]
 
 
 def p_number(p):
@@ -1088,7 +1093,7 @@ def p_function_call(p):
     | CURRENT_DATE LPAREN RPAREN"""
     if len(p) == 5:
         distinct = p[3] is None or (
-            isinstance(p[3], str) and p[3].upper() == "DISTINCT"
+                isinstance(p[3], str) and p[3].upper() == "DISTINCT"
         )
         p[0] = FunctionCall(
             p.lineno(1), p.lexpos(1), name=p[1], distinct=distinct, arguments=p[3]

--- a/src/static/umi.14ee9910.js
+++ b/src/static/umi.14ee9910.js
@@ -151,7 +151,7 @@ A`,g,g,0,x?1:0,1,c.p1.x,c.p1.y)}return i.join(" ")}}function r_(r,n){n=n||{},n.m
     WHERE table_schema = '`).concat(E,"' AND table_name in (").concat(rt,`)
     AND (0x00) IN (@indexes:=CONCAT_WS(',', @indexes, CONCAT('{"schema":"',indexes.table_schema,'","table":"',indexes.table_name,'",
     "name":"', indexes.index_name, '","column":"', indexes.column_name, '",
-    "cardinality":', indexes.cardinality, ',"unique":', IF(indexes.non_unique = 1, 'false', 'true'), '}')))) ) indexes,
+    "cardinality":', IFNULL(indexes.cardinality, 0), ',"unique":', IF(indexes.non_unique = 1, 'false', 'true'), '}')))) ) indexes,
     (SELECT (@tbls:=NULL), (SELECT (0) FROM information_schema.tables tbls
     WHERE table_schema = '`).concat(E,"' AND table_name in (").concat(rt,`) AND (0x00) IN
     (@tbls:=CONCAT_WS(',', @tbls, CONCAT('{', '"schema":"', \`TABLE_SCHEMA\`, '",', '"table":"', \`TABLE_NAME\`, '",', '"rows":',

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,6 +8,6 @@
 </head>
 <body>
 <div id="root-master"></div>
-<script src="{{ url_for('static', filename='umi.3305ccbe.js') }}" entry="" crossorigin="anonymous"></script>
+<script src="{{ url_for('static', filename='umi.14ee9910.js') }}" entry="" crossorigin="anonymous"></script>
 
 </body></html>

--- a/test/parser/test_parser_dql.py
+++ b/test/parser/test_parser_dql.py
@@ -38,9 +38,9 @@ class MyTestCase(unittest.TestCase):
         result = oceanbase_parser.parse("select distinct name from a.blog")
         query_body = result.query_body
         assert (
-            query_body is not None
-            and query_body.limit == 0
-            and query_body.where is None
+                query_body is not None
+                and query_body.limit == 0
+                and query_body.where is None
         )
 
     def test_question_mark(self):
@@ -286,6 +286,13 @@ SELECT          server_release_repo.server_release_repo_id,    server_release_re
         result = oceanbase_parser.parse(
             """
         SELECT * FROM `antinvoice93`.einv_base_info WHERE einv_source = ? ORDER BY gmt_create DESC LIMIT ?
+        """
+        )
+        assert result.query_body.limit == '?'
+
+        result = oceanbase_parser.parse(
+            """
+        SELECT * FROM `antinvoice93`.einv_base_info WHERE einv_source = ? ORDER BY gmt_create DESC LIMIT 1,?
         """
         )
         assert result.query_body.limit == '?'

--- a/test/parser/test_parser_dql.py
+++ b/test/parser/test_parser_dql.py
@@ -38,9 +38,9 @@ class MyTestCase(unittest.TestCase):
         result = oceanbase_parser.parse("select distinct name from a.blog")
         query_body = result.query_body
         assert (
-                query_body is not None
-                and query_body.limit == 0
-                and query_body.where is None
+            query_body is not None
+            and query_body.limit == 0
+            and query_body.where is None
         )
 
     def test_question_mark(self):


### PR DESCRIPTION
### Task Description

The previous support for limit parameterization was not comprehensive enough to complete all possible scenarios
Extract parametric and non-parametric point to make the structure clearer

By the way, modify .gitignore and fix the front-end bug
* https://github.com/oceanbase/sql-lifecycle-management/issues/101
* https://github.com/oceanbase/sql-lifecycle-management/issues/99

